### PR TITLE
fix: import to be compatible with newer Django versions

### DIFF
--- a/django_admin_filter/urls.py
+++ b/django_admin_filter/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path
+from django.urls import re_path
 from .views import CreateFilterQueryView, UpdateFilterQueryView
 from . import settings
 


### PR DESCRIPTION
`urls` module is now under `django.urls` instead of `django.conf.urls` Django 2.x onwards.
